### PR TITLE
Update ducktape to v0.16.9

### DIFF
--- a/Formula/ducktape.rb
+++ b/Formula/ducktape.rb
@@ -1,9 +1,9 @@
 class Ducktape < Formula
   desc "AI-powered terminal tool for Apple Calendar, Reminders and Notes"
   homepage "https://github.com/ducktapeai/ducktape"
-  url "https://github.com/ducktapeai/ducktape/archive/v0.16.8.tar.gz"
-  version "0.16.8"
-  sha256 "4b7d13c1b8111ff82c67276c1b39654124c6d691055c0aafe745413780cf4c1d"
+  url "https://github.com/ducktapeai/ducktape/archive/v0.16.9.tar.gz"
+  version "0.16.9"
+  sha256 "028e4280928727ca0841c255ed84ae73255352e108696e465baeb6dd54ec45f0"
   license "MIT"
 
   depends_on "rust" => :build


### PR DESCRIPTION
This PR updates the Ducktape formula to version 0.16.9, including:\n\n- Enhanced contact extraction functionality for calendar events\n- Support for 'and invite' pattern in natural language commands\n- Fixed compilation issues in parser modules\n- Improved error handling in command processing\n\nThe tarball's SHA256 checksum has been updated accordingly.